### PR TITLE
Support other install locations

### DIFF
--- a/lib/GoogleDocsCodePaste/rtf_template.lua
+++ b/lib/GoogleDocsCodePaste/rtf_template.lua
@@ -62,7 +62,7 @@ local function generateHighlightedCode(code, language)
   io.write(code)
   io.close(file)
 
-  local codeRtf = hs.execute("cat /tmp/code.txt | /usr/local/bin/highlight --no-trailing-nl -O rtf --font 'Roboto Mono' --font-size 16 --syntax " .. language .. " -s 'solarized-light'")
+  local codeRtf = hs.execute("cat /tmp/code.txt | highlight --no-trailing-nl -O rtf --font 'Roboto Mono' --font-size 16 --syntax " .. language .. " -s 'solarized-light'", true)
   hs.execute("rm /tmp/code.txt")
 
   return codeRtf


### PR DESCRIPTION
Homebrew also uses /opt/homebrew/bin now. By using the user's env, we can find highlight wherever it is installed